### PR TITLE
allow multiple standalone server deployments

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,11 @@ owncloud_apt_cache_update: False
 owncloud_packages_extra: []
 
 owncloud_autosetup: True
+# @var owncloud_setup_run_once:description: >
+# Run the occ setup command only once on the first host of the group. This setting is only required for
+# cluster setups. If you want to install multiple standalone instances with the same play set it to `False`.
+# @end
+owncloud_setup_run_once: True
 owncloud_admin_username: admin
 owncloud_admin_password: owncloud
 

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -154,7 +154,7 @@
     "--admin-user={{ owncloud_admin_username }}"
     "--admin-pass={{ owncloud_admin_password }}"
     {% endif %}
-  run_once: True
+  run_once: "{{ owncloud_setup_run_once | bool }}"
   become: True
   become_user: "{{ owncloud_app_user }}"
 


### PR DESCRIPTION
Will fix https://github.com/owncloud-ansible/owncloud/issues/27

Default was set to `True` to avoid a breaking change.