### PR TITLE
use php without --file flag

### DIFF
--- a/templates/usr/local/bin/occ.j2
+++ b/templates/usr/local/bin/occ.j2
@@ -7,10 +7,10 @@ set -euo pipefail
 
 : "${USER:=nobody}"
 
-cd '{{ owncloud_deploy_path }}' || exit 1
+cd {{ owncloud_deploy_path }} || exit 1
 
-if [ "$USER" == '{{ owncloud_app_user }}' ]; then
-	{{ php_executable }} --file '{{ owncloud_deploy_path }}/occ' "$@"
+if [ "$USER" == "{{ owncloud_app_user }}" ]; then
+	{{ php_executable }} {{ owncloud_deploy_path }}/occ "$@"
 else
-	sudo -E -u '{{ owncloud_app_user }}' {{ php_executable }} --file '{{ owncloud_deploy_path }}/occ' "$@"
+	sudo -E -u {{ owncloud_app_user }} {{ php_executable }} {{ owncloud_deploy_path }} "$@"
 fi

--- a/templates/usr/local/bin/occ.j2
+++ b/templates/usr/local/bin/occ.j2
@@ -12,5 +12,5 @@ cd {{ owncloud_deploy_path }} || exit 1
 if [ "$USER" == "{{ owncloud_app_user }}" ]; then
 	{{ php_executable }} {{ owncloud_deploy_path }}/occ "$@"
 else
-	sudo -E -u {{ owncloud_app_user }} {{ php_executable }} {{ owncloud_deploy_path }} "$@"
+	sudo -E -u {{ owncloud_app_user }} {{ php_executable }} {{ owncloud_deploy_path }}/occ "$@"
 fi


### PR DESCRIPTION
`occ --help` does not output the occ help but the php help instead:

```
root@ubuntu-18:~# occ --help
Usage: php [options] [-f] <file> [--] [args...]
   php [options] -r <code> [--] [args...]
   php [options] [-B <begin_code>] -R <code> [-E <end_code>] [--] [args...]
   php [options] [-B <begin_code>] -F <file> [-E <end_code>] [--] [args...]
   php [options] -S <addr>:<port> [-t docroot] [router]
   php [options] -- [args...]
   php [options] -a
```

This PR is removing the `--file` flag to successfully forward cli flags to `occ`