### PR TITLE
Change include conditionals (support jinja2_native=True)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
       paths:
         - "vars"
     var_files: "{{ lookup('first_found', params, errors='ignore') }}"
-  when: var_files | length
+  when: var_files
 - include_tasks: overwrites.yml
 
 - include_tasks: prepare.yml
@@ -21,7 +21,7 @@
       paths:
         - "tasks"
     task_files: "{{ lookup('first_found', params, errors='ignore') }}"
-  when: task_files | length
+  when: task_files
 
 - include_tasks: config.yml
 - include_tasks: post.yml


### PR DESCRIPTION
When using the jinja2_native option the files lookups will correctly return `null` when no match is found. This lead to the playbook crashing for such cases. This commit changes the conditions to simply check the truthyness of the result.
Which could be a greater than 0 length string when a match was found, or either an empty string (jinja2_native=false) or `null` (jinja2_native=true) when no match was found.

See the [Ansible Config Ref](https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-jinja2-native) and the [Jinja2 Doc](https://jinja.palletsprojects.com/en/2.11.x/nativetypes/) for details on the native environment.

The difference in observed values for the negative case (i.e., no files found) and the correctness of the proposed change can also be easily checked by running the following play. (Note that you will have to add file matching the format to check the positive case.)

```yaml
- name: PoC
  hosts: localhost
  gather_facts: yes
  vars:
    params:
      files:
        - "configure-{{ ansible_os_family | lower }}.yml"
      paths:
        - "tasks"
    task_files: "{{ lookup('first_found', params, errors='ignore') }}"
  tasks:
    - debug:
        var: params
    - debug:
        var: task_files
    - name: conditional
      debug:
        msg: executed conditional
      when: task_files
```
```
# ansible.cfg
...
# This option preserves variable types during template operations. This requires Jinja2 >= 2.10.
jinja2_native = True # False is the default
...
```

The same "issue" is found in all other owncloud ansible roles. For now I have only opened a PR for this role and [owncloud-ansible/php](https://github.com/owncloud-ansible/php), but am willing open PRs for the remaining roles if you OK these PRs.

See https://github.com/owncloud-ansible/php/pull/16
