### PR TITLE
Cleaning up defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-owncloud_version: "10.5.0"
+owncloud_version: "10.7.0"
 
 # @var owncloud_download_url:description: >
 # You can set a custom download url especialy for the enterprise version.
@@ -70,31 +70,31 @@ owncloud_skeleton_path: "{{ owncloud_deploy_path }}/core/skeleton"
 # limited to owncloud user/group
 # owncloud_temp_path: # defaults to not set
 
-owncloud_share_api_enabled: True
-owncloud_share_api_allow_links: True
-owncloud_share_api_allow_public_upload: True
-owncloud_share_api_enforce_password_links_read_only: False
-owncloud_share_api_enforce_password_links_read_write: False
-owncloud_share_api_enforce_password_links_write_only: False
-owncloud_share_api_default_expire_date: True
-owncloud_share_api_enforce_expire_date: False
-owncloud_share_api_expire_after_n_days: 7
-owncloud_share_api_allow_public_notification: False
+# owncloud_share_api_enabled: True
+# owncloud_share_api_allow_links: True
+# owncloud_share_api_allow_public_upload: True
+# owncloud_share_api_enforce_password_links_read_only: False
+# owncloud_share_api_enforce_password_links_read_write: False
+# owncloud_share_api_enforce_password_links_write_only: False
+# owncloud_share_api_default_expire_date: True
+# owncloud_share_api_enforce_expire_date: False
+# owncloud_share_api_expire_after_n_days: 7
+# owncloud_share_api_allow_public_notification: False
 # owncloud_share_api_public_notification_language: en # defaults to not set
-owncloud_share_api_allow_social_share: True
-owncloud_share_api_auto_accept_share: False
-owncloud_share_api_allow_resharing: False
-owncloud_share_api_allow_group_sharing: False
-owncloud_share_api_only_share_with_group_members: True
-owncloud_share_api_only_share_with_membership_groups: True
-owncloud_share_api_allow_mail_notification: True
-owncloud_share_api_allow_share_dialog_user_enumeration: True
-owncloud_share_api_share_dialog_user_enumeration_group_members: False
+# owncloud_share_api_allow_social_share: True
+# owncloud_share_api_auto_accept_share: False
+# owncloud_share_api_allow_resharing: False
+# owncloud_share_api_allow_group_sharing: False
+# owncloud_share_api_only_share_with_group_members: True
+# owncloud_share_api_only_share_with_membership_groups: True
+# owncloud_share_api_allow_mail_notification: True
+# owncloud_share_api_allow_share_dialog_user_enumeration: True
+# owncloud_share_api_share_dialog_user_enumeration_group_members: False
 
-owncloud_federation_auto_add_servers: False
-owncloud_federation_auto_accept_trusted: False
-owncloud_federation_allow_outgoing_server2server_share: True
-owncloud_federation_allow_incoming_server2server_share: True
+# owncloud_federation_auto_add_servers: False
+# owncloud_federation_auto_accept_trusted: False
+# owncloud_federation_allow_outgoing_server2server_share: True
+# owncloud_federation_allow_incoming_server2server_share: True
 
 # owncloud_mail_domain: example.com # defaults to not set
 # owncloud_mail_from_address: owncloud # defaults to not set
@@ -102,7 +102,7 @@ owncloud_federation_allow_incoming_server2server_share: True
 # owncloud_mail_smtp_host: "smtp.example.com" # defaults to not set
 # owncloud_mail_smtp_port: "587" # defaults to not set
 # owncloud_mail_smtp_secure: ssl # defaults to not set
-owncloud_mail_smtp_auth_enabled: False
+# owncloud_mail_smtp_auth_enabled: False
 # owncloud_mail_smtp_auth_type: "PLAIN" # defaults to not set
 # owncloud_mail_smtp_auth_name: admin@example.com # defaults to not set
 # owncloud_mail_smtp_auth_password: "very_secure" # defaults to not set
@@ -118,7 +118,7 @@ owncloud_mail_smtp_auth_enabled: False
 # owncloud_password_history_blacklist: # (number)
 # owncloud_password_expiration: # (days)
 # owncloud_password_expiration_notification: # (seconds)
-owncloud_password_force_change_on_first_login: False
+# owncloud_password_force_change_on_first_login: False
 
 owncloud_log_type: owncloud
 owncloud_log_file: "{{ owncloud_data_path }}/owncloud.log"
@@ -216,17 +216,13 @@ owncloud_apps_deprecated: []
 #     state: present
 # @end
 
-owncloud_apps:
-  - name: twofactor_totp
-  - name: password_policy
-
-owncloud_app_documents_provider: onlyoffice
-owncloud_app_documents_enabled: False
+# owncloud_app_documents_provider: onlyoffice
+# owncloud_app_documents_enabled: False
 
 owncloud_apps_config: []
 
 # @var owncloud_encryption_enabled:description: >
 # Only supported for ownCloud >= 10.2.1
 # @end
-owncloud_encryption_enabled: False
-owncloud_encryption_force_encrypt_all: False
+# owncloud_encryption_enabled: False
+# owncloud_encryption_force_encrypt_all: False

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -70,7 +70,7 @@ owncloud_skeleton_path: "{{ owncloud_deploy_path }}/core/skeleton"
 # limited to owncloud user/group
 # owncloud_temp_path: # defaults to not set
 
-# owncloud_share_api_enabled: True
+owncloud_share_api_enabled: True
 # owncloud_share_api_allow_links: True
 # owncloud_share_api_allow_public_upload: True
 # owncloud_share_api_enforce_password_links_read_only: False
@@ -215,6 +215,7 @@ owncloud_apps_deprecated: []
 #     force_basic_auth: true
 #     state: present
 # @end
+owncloud_apps: []
 
 # owncloud_app_documents_provider: onlyoffice
 # owncloud_app_documents_enabled: False

--- a/molecule/centos7/tests/test_default.py
+++ b/molecule/centos7/tests/test_default.py
@@ -30,5 +30,5 @@ def test_owncloud_web(host):
 def test_owncloud_cli(host):
     status = host.run("/usr/local/bin/occ status | tr -d ' '").stdout
 
-    assert "versionstring:10.5.0" in status
+    assert "versionstring:10.7.0" in status
     assert "installed:true" in status

--- a/molecule/centos8/tests/test_default.py
+++ b/molecule/centos8/tests/test_default.py
@@ -30,5 +30,5 @@ def test_owncloud_web(host):
 def test_owncloud_cli(host):
     status = host.run("/usr/local/bin/occ status | tr -d ' '").stdout
 
-    assert "versionstring:10.5.0" in status
+    assert "versionstring:10.7.0" in status
     assert "installed:true" in status

--- a/molecule/opensuse15/tests/test_default.py
+++ b/molecule/opensuse15/tests/test_default.py
@@ -30,5 +30,5 @@ def test_owncloud_web(host):
 def test_owncloud_cli(host):
     status = host.run("/usr/local/bin/occ status | tr -d ' '").stdout
 
-    assert "versionstring:10.5.0" in status
+    assert "versionstring:10.7.0" in status
     assert "installed:true" in status

--- a/molecule/ubuntu1804/tests/test_default.py
+++ b/molecule/ubuntu1804/tests/test_default.py
@@ -30,5 +30,5 @@ def test_owncloud_web(host):
 def test_owncloud_cli(host):
     status = host.run("occ status | tr -d ' '").stdout
 
-    assert "versionstring:10.5.0" in status
+    assert "versionstring:10.7.0" in status
     assert "installed:true" in status

--- a/tasks/apps.yml
+++ b/tasks/apps.yml
@@ -55,6 +55,6 @@
       changed_when: False
   when:
     - owncloud_current_version is version_compare("10.2.1", operator=">=", strict=True)
-    - owncloud_encryption_enabled | bool
+    - owncloud_encryption_enabled is defined 
   become: True
   become_user: "{{ owncloud_app_user }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -112,77 +112,77 @@ __occ_core_config:
     state: "{{ 'present' if owncloud_privacy_policy_url is defined else 'absent' }}"
   - name: core
     attr: "shareapi_enabled"
-    value: "{{ 'yes' if owncloud_share_api_enabled | bool else 'no' }}"
+    value: "{{ 'yes' if owncloud_share_api_enabled is defined else 'no' }}"
   - name: core
     attr: "shareapi_allow_links"
-    value: "{{ 'yes' if owncloud_share_api_allow_links | bool else 'no' }}"
+    value: "{{ 'yes' if owncloud_share_api_allow_links is defined else 'no' }}"
   - name: core
     attr: "shareapi_allow_public_upload"
-    value: "{{ 'yes' if owncloud_share_api_allow_public_upload | bool else 'no' }}"
+    value: "{{ 'yes' if owncloud_share_api_allow_public_upload is defined else 'no' }}"
   - name: core
     attr: "shareapi_enforce_links_password_read_only"
-    value: "{{ 'yes' if owncloud_share_api_enforce_password_links_read_only | bool else 'no' }}"
+    value: "{{ 'yes' if owncloud_share_api_enforce_password_links_read_only is defined else 'no' }}"
   - name: core
     attr: "shareapi_enforce_links_password_read_write"
-    value: "{{ 'yes' if owncloud_share_api_enforce_password_links_read_write | bool else 'no' }}"
+    value: "{{ 'yes' if owncloud_share_api_enforce_password_links_read_write is defined else 'no' }}"
   - name: core
     attr: "shareapi_enforce_links_password_write_only"
-    value: "{{ 'yes' if owncloud_share_api_enforce_password_links_write_only | bool else 'no' }}"
+    value: "{{ 'yes' if owncloud_share_api_enforce_password_links_write_only is defined else 'no' }}"
   - name: core
     attr: "shareapi_default_expire_date"
-    value: "{{ 'yes' if owncloud_share_api_default_expire_date | bool else 'no' }}"
+    value: "{{ 'yes' if owncloud_share_api_default_expire_date is defined else 'no' }}"
   - name: core
     attr: "shareapi_enforce_expire_date"
-    value: "{{ 'yes' if owncloud_share_api_enforce_expire_date | bool else 'no' }}"
+    value: "{{ 'yes' if owncloud_share_api_enforce_expire_date is defined else 'no' }}"
   - name: core
     attr: "shareapi_expire_after_n_days"
-    value: "{{ owncloud_share_api_expire_after_n_days }}"
+    value: "{{ owncloud_share_api_expire_after_n_days | default('') }}"
   - name: core
     attr: "shareapi_allow_public_notification"
-    value: "{{ 'yes' if owncloud_share_api_allow_public_notification | bool else 'no' }}"
+    value: "{{ 'yes' if owncloud_share_api_allow_public_notification is defined else 'no' }}"
   - name: core
     attr: "shareapi_public_notification_lang"
     value: "{{ owncloud_share_api_public_notification_language | default('') }}"
     state: "{{ 'present' if owncloud_share_api_public_notification_language is defined else 'absent' }}"
   - name: core
     attr: "shareapi_allow_social_share"
-    value: "{{ 'yes' if owncloud_share_api_allow_social_share | bool else 'no' }}"
+    value: "{{ 'yes' if owncloud_share_api_allow_social_share is defined else 'no' }}"
   - name: core
     attr: "shareapi_auto_accept_share"
-    value: "{{ 'yes' if owncloud_share_api_auto_accept_share | bool else 'no' }}"
+    value: "{{ 'yes' if owncloud_share_api_auto_accept_share is defined else 'no' }}"
   - name: core
     attr: "shareapi_allow_resharing"
-    value: "{{ 'yes' if owncloud_share_api_allow_resharing | bool else 'no' }}"
+    value: "{{ 'yes' if owncloud_share_api_allow_resharing is defined else 'no' }}"
   - name: core
     attr: "shareapi_allow_group_sharing"
-    value: "{{ 'yes' if owncloud_share_api_allow_group_sharing | bool else 'no' }}"
+    value: "{{ 'yes' if owncloud_share_api_allow_group_sharing is defined else 'no' }}"
   - name: core
     attr: "shareapi_only_share_with_group_members"
-    value: "{{ 'yes' if owncloud_share_api_only_share_with_group_members | bool else 'no' }}"
+    value: "{{ 'yes' if owncloud_share_api_only_share_with_group_members is defined else 'no' }}"
   - name: core
     attr: "shareapi_only_share_with_membership_groups"
-    value: "{{ 'yes' if owncloud_share_api_only_share_with_membership_groups | bool else 'no' }}"
+    value: "{{ 'yes' if owncloud_share_api_only_share_with_membership_groups is defined else 'no' }}"
   - name: core
     attr: "shareapi_allow_mail_notification"
-    value: "{{ 'yes' if owncloud_share_api_allow_mail_notification | bool else 'no' }}"
+    value: "{{ 'yes' if owncloud_share_api_allow_mail_notification is defined else 'no' }}"
   - name: core
     attr: "shareapi_allow_share_dialog_user_enumeration"
-    value: "{{ 'yes' if owncloud_share_api_allow_share_dialog_user_enumeration | bool else 'no' }}"
+    value: "{{ 'yes' if owncloud_share_api_allow_share_dialog_user_enumeration is defined else 'no' }}"
   - name: core
     attr: "shareapi_share_dialog_user_enumeration_group_members"
-    value: "{{ 'yes' if owncloud_share_api_share_dialog_user_enumeration_group_members | bool else 'no' }}"
+    value: "{{ 'yes' if owncloud_share_api_share_dialog_user_enumeration_group_members is defined else 'no' }}"
   - name: federation
     attr: "autoAddServers"
-    value: "{{ '1' if owncloud_federation_auto_add_servers | bool else '0' }}"
+    value: "{{ '1' if owncloud_federation_auto_add_servers is defined else '0' }}"
   - name: federatedfilesharing
     attr: "auto_accept_trusted"
-    value: "{{ 'yes' if owncloud_federation_auto_accept_trusted | bool else 'no' }}"
+    value: "{{ 'yes' if owncloud_federation_auto_accept_trusted is defined else 'no' }}"
   - name: files_sharing
     attr: "outgoing_server2server_share_enabled"
-    value: "{{ 'yes' if owncloud_federation_allow_outgoing_server2server_share | bool else 'no' }}"
+    value: "{{ 'yes' if owncloud_federation_allow_outgoing_server2server_share is defined else 'no' }}"
   - name: files_sharing
     attr: "incoming_server2server_share_enabled"
-    value: "{{ 'yes' if owncloud_federation_allow_incoming_server2server_share | bool else 'no' }}"
+    value: "{{ 'yes' if owncloud_federation_allow_incoming_server2server_share is defined else 'no' }}"
   - name: system
     attr: mail_domain
     value: "{{ owncloud_mail_domain | default('') }}"
@@ -209,7 +209,7 @@ __occ_core_config:
     state: '{{ "present" if owncloud_mail_smtp_secure is defined else "absent" }}'
   - name: system
     attr: mail_smtpauth
-    value: "{{ '1' if owncloud_mail_smtp_auth_enabled else '' }}"
+    value: "{{ '1' if owncloud_mail_smtp_auth_enabled is defined else '0' }}"
     state: '{{ "present" if owncloud_mail_smtp_auth_enabled is defined else "absent" }}'
   - name: system
     attr: mail_smtpauthtype
@@ -266,7 +266,7 @@ __occ_core_config:
   - name: password_policy
     attr: spv_user_password_force_change_on_first_login_checked
     value: "on"
-    state: "{{ 'present' if owncloud_password_force_change_on_first_login else 'absent' }}"
+    state: "{{ 'present' if owncloud_password_force_change_on_first_login is defined else 'absent' }}"
   - name: password_policy
     attr: spv_def_special_chars_checked
     value: "on"


### PR DESCRIPTION
Adjusting defaults, to no longer deviate from standard ownCloud configuration.
This should have the advantage to be able to run on more setups without having to go through every single configuration option in ownCloud.