### PR TITLE
fix: ensure package `acl` is installed as dependency

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -9,6 +9,7 @@ __owncloud_packages:
   - unzip
   - bzip2
   - rsync
+  - acl
 
 __owncloud_enable_sebooleans:
   - httpd_can_network_connect_db


### PR DESCRIPTION
add `acl` package to `owncloud_packages`.

Without it my Ansible deployment fails with:

```
TASK [owncloud : Get ownCloud setup status] **************************************************************************************
fatal: [10.211.55.6]: FAILED! => {"msg": "Failed to set permissions on the temporary files Ansible needs to create when becoming an unprivileged user (rc: 1, err: chmod: invalid mode: 'A+user:www-data:rx:allow'\nTry 'chmod --help' for more information.\n}). For information on working around this, see https://docs.ansible.com/ansible-core/2.11/user_guide/become.html#becoming-an-unprivileged-user"}
```

at this step:

```
- name: Get ownCloud setup status
  command: "{{ owncloud_occ_executable | quote }} check"
  register: __owncloud_register_occ_check
  changed_when: False
  become: True
  become_user: "{{ owncloud_app_user }}"
```

verbose output

```
TASK [owncloud : Get ownCloud setup status] ************************************************************************************
task path: /Users/dmitry/.ansible/roles/owncloud/tasks/setup.yml:125
<10.211.55.6> ESTABLISH SSH CONNECTION FOR USER: ansible
<10.211.55.6> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o 'User="ansible"' -o ConnectTimeout=10 -o ControlPath=/Users/dmitry/.ansible/cp/2a4279f926 10.211.55.6 '/bin/sh -c '"'"'echo ~ansible && sleep 0'"'"''
<10.211.55.6> (0, b'/home/ansible\n', b'')
<10.211.55.6> ESTABLISH SSH CONNECTION FOR USER: ansible
<10.211.55.6> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o 'User="ansible"' -o ConnectTimeout=10 -o ControlPath=/Users/dmitry/.ansible/cp/2a4279f926 10.211.55.6 '/bin/sh -c '"'"'( umask 77 && mkdir -p "` echo /var/tmp `"&& mkdir "` echo /var/tmp/ansible-tmp-1644712902.600127-52457-249062905870500 `" && echo ansible-tmp-1644712902.600127-52457-249062905870500="` echo /var/tmp/ansible-tmp-1644712902.600127-52457-249062905870500 `" ) && sleep 0'"'"''
<10.211.55.6> (0, b'ansible-tmp-1644712902.600127-52457-249062905870500=/var/tmp/ansible-tmp-1644712902.600127-52457-249062905870500\n', b'')
Using module file /Library/Python/3.8/site-packages/ansible/modules/command.py
<10.211.55.6> PUT /Users/dmitry/.ansible/tmp/ansible-local-515335blev2qb/tmpphoxlug7 TO /var/tmp/ansible-tmp-1644712902.600127-52457-249062905870500/AnsiballZ_command.py
<10.211.55.6> SSH: EXEC sftp -b - -C -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o 'User="ansible"' -o ConnectTimeout=10 -o ControlPath=/Users/dmitry/.ansible/cp/2a4279f926 '[10.211.55.6]'
<10.211.55.6> (0, b'sftp> put /Users/dmitry/.ansible/tmp/ansible-local-515335blev2qb/tmpphoxlug7 /var/tmp/ansible-tmp-1644712902.600127-52457-249062905870500/AnsiballZ_command.py\n', b'')
<10.211.55.6> ESTABLISH SSH CONNECTION FOR USER: ansible
<10.211.55.6> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o 'User="ansible"' -o ConnectTimeout=10 -o ControlPath=/Users/dmitry/.ansible/cp/2a4279f926 10.211.55.6 '/bin/sh -c '"'"'setfacl -m u:www-data:r-x /var/tmp/ansible-tmp-1644712902.600127-52457-249062905870500/ /var/tmp/ansible-tmp-1644712902.600127-52457-249062905870500/AnsiballZ_command.py && sleep 0'"'"''
<10.211.55.6> (127, b'', b'/bin/sh: 1: setfacl: not found\n')
<10.211.55.6> Failed to connect to the host via ssh: /bin/sh: 1: setfacl: not found
<10.211.55.6> ESTABLISH SSH CONNECTION FOR USER: ansible
<10.211.55.6> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o 'User="ansible"' -o ConnectTimeout=10 -o ControlPath=/Users/dmitry/.ansible/cp/2a4279f926 10.211.55.6 '/bin/sh -c '"'"'chmod u+x /var/tmp/ansible-tmp-1644712902.600127-52457-249062905870500/ /var/tmp/ansible-tmp-1644712902.600127-52457-249062905870500/AnsiballZ_command.py && sleep 0'"'"''
<10.211.55.6> (0, b'', b'')
<10.211.55.6> ESTABLISH SSH CONNECTION FOR USER: ansible
<10.211.55.6> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o 'User="ansible"' -o ConnectTimeout=10 -o ControlPath=/Users/dmitry/.ansible/cp/2a4279f926 10.211.55.6 '/bin/sh -c '"'"'chown www-data /var/tmp/ansible-tmp-1644712902.600127-52457-249062905870500/ /var/tmp/ansible-tmp-1644712902.600127-52457-249062905870500/AnsiballZ_command.py && sleep 0'"'"''
<10.211.55.6> (1, b'', b"chown: changing ownership of '/var/tmp/ansible-tmp-1644712902.600127-52457-249062905870500/': Operation not permitted\nchown: changing ownership of '/var/tmp/ansible-tmp-1644712902.600127-52457-249062905870500/AnsiballZ_command.py': Operation not permitted\n")
<10.211.55.6> Failed to connect to the host via ssh: chown: changing ownership of '/var/tmp/ansible-tmp-1644712902.600127-52457-249062905870500/': Operation not permitted
chown: changing ownership of '/var/tmp/ansible-tmp-1644712902.600127-52457-249062905870500/AnsiballZ_command.py': Operation not permitted
<10.211.55.6> ESTABLISH SSH CONNECTION FOR USER: ansible
<10.211.55.6> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o 'User="ansible"' -o ConnectTimeout=10 -o ControlPath=/Users/dmitry/.ansible/cp/2a4279f926 10.211.55.6 '/bin/sh -c '"'"'chmod +a '"'"'"'"'"'"'"'"'www-data allow read,execute'"'"'"'"'"'"'"'"' /var/tmp/ansible-tmp-1644712902.600127-52457-249062905870500/ /var/tmp/ansible-tmp-1644712902.600127-52457-249062905870500/AnsiballZ_command.py && sleep 0'"'"''
<10.211.55.6> (1, b'', b"chmod: invalid mode: '+a'\nTry 'chmod --help' for more information.\n")
<10.211.55.6> Failed to connect to the host via ssh: chmod: invalid mode: '+a'
Try 'chmod --help' for more information.
<10.211.55.6> ESTABLISH SSH CONNECTION FOR USER: ansible
<10.211.55.6> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o 'User="ansible"' -o ConnectTimeout=10 -o ControlPath=/Users/dmitry/.ansible/cp/2a4279f926 10.211.55.6 '/bin/sh -c '"'"'chmod A+user:www-data:rx:allow /var/tmp/ansible-tmp-1644712902.600127-52457-249062905870500/ /var/tmp/ansible-tmp-1644712902.600127-52457-249062905870500/AnsiballZ_command.py && sleep 0'"'"''
<10.211.55.6> (1, b'', b"chmod: invalid mode: 'A+user:www-data:rx:allow'\nTry 'chmod --help' for more information.\n")
<10.211.55.6> Failed to connect to the host via ssh: chmod: invalid mode: 'A+user:www-data:rx:allow'
Try 'chmod --help' for more information.
<10.211.55.6> ESTABLISH SSH CONNECTION FOR USER: ansible
<10.211.55.6> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o 'User="ansible"' -o ConnectTimeout=10 -o ControlPath=/Users/dmitry/.ansible/cp/2a4279f926 10.211.55.6 '/bin/sh -c '"'"'rm -f -r /var/tmp/ansible-tmp-1644712902.600127-52457-249062905870500/ > /dev/null 2>&1 && sleep 0'"'"''
<10.211.55.6> (0, b'', b'')
fatal: [10.211.55.6]: FAILED! => {
    "msg": "Failed to set permissions on the temporary files Ansible needs to create when becoming an unprivileged user (rc: 1, err: chmod: invalid mode: 'A+user:www-data:rx:allow'\nTry 'chmod --help' for more information.\n}). For information on working around this, see https://docs.ansible.com/ansible-core/2.11/user_guide/become.html#becoming-an-unprivileged-user"
}
```