### PR TITLE
fix: replace deprecated default download server url

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ owncloud_version: "10.9.0"
 # @var owncloud_download_url:description: >
 # You can set a custom download url especialy for the enterprise version.
 # @end
-owncloud_download_url: "https://download.owncloud.org/community/owncloud-{{ owncloud_version }}.tar.bz2"
+owncloud_download_url: "https://download.owncloud.com/server/stable/owncloud-{{ owncloud_version }}.tar.bz2"
 
 # owncloud_download_auth_user: #
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -241,6 +241,16 @@ owncloud_apps:
 owncloud_app_documents_provider: onlyoffice
 owncloud_app_documents_enabled: False
 
+# @var owncloud_apps_config:description: >
+# Manages ownCloud system and app config. The name attribute holds the name of the app which is either 'system' or '<app_name>'. 'attribute' in the parameters dictionary hold the attribute of the app and 'value' the value it should be set to
+# @end
+# @var owncloud_apps_config:example: >
+# owncloud_apps_config:
+#  - name: files
+#    parameters:
+#      - attribute: default_quota
+#        value: "0 B"
+# @end
 owncloud_apps_config: []
 
 # @var owncloud_encryption_enabled:description: >

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -244,7 +244,8 @@ owncloud_app_documents_provider: onlyoffice
 owncloud_app_documents_enabled: False
 
 # @var owncloud_apps_config:description: >
-# Manages ownCloud system and app config. The name attribute holds the name of the app which is either 'system' or '<app_name>'. 'attribute' in the parameters dictionary hold the attribute of the app and 'value' the value it should be set to
+# Manages ownCloud system and app configuration. The name attribute holds the name of the app which is either `system` or `<app_name>`.
+# The `attribute` in the parameters dictionary hold the attribute of the app and `value` the new value to set.
 # @end
 # @var owncloud_apps_config:example: >
 # owncloud_apps_config:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -246,10 +246,10 @@ owncloud_app_documents_enabled: False
 # @end
 # @var owncloud_apps_config:example: >
 # owncloud_apps_config:
-#  - name: files
-#    parameters:
-#      - attribute: default_quota
-#        value: "0 B"
+#   - name: files
+#     parameters:
+#       - attribute: default_quota
+#         value: "0 B"
 # @end
 owncloud_apps_config: []
 


### PR DESCRIPTION
After some internal discussion it seems the URL has to be adjusted as version 10.10 is not available in the old default URL but in the new one contained in this PR.