### PR TITLE
fix: enable maintenance mode after asset fetching

### DIFF
--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -1,23 +1,5 @@
 ---
 - block:
-    - name: Disable deprecated ownCloud apps
-      oc_app:
-        name: "{{ item }}"
-        enabled: no
-        executable: "{{ owncloud_occ_executable | default(omit) }}"
-        state: current
-      loop: "{{ owncloud_apps_deprecated }}"
-      when: ansible_local.owncloud.installed | bool or ansible_local.owncloud.maintenance | bool
-
-    - name: Enable maintainance mode
-      command: "{{ owncloud_occ_executable | quote }} maintenance:singleuser --on"
-      when:
-        - ansible_local.owncloud.installed | bool
-        - __occ_bin_link.stat.exists
-        - __occ_bin_src.stat.exists
-      become: True
-      become_user: "{{ owncloud_app_user }}"
-
     - name: Create temp directory
       file:
         path: /tmp/owncloud_src
@@ -49,6 +31,26 @@
   when:
     - owncloud_current_version is version_compare(owncloud_version, operator="<", strict=True)
     - not owncloud_install_from_filesystem | bool
+
+- block:
+    - name: Disable deprecated ownCloud apps
+      oc_app:
+        name: "{{ item }}"
+        enabled: no
+        executable: "{{ owncloud_occ_executable | default(omit) }}"
+        state: current
+      loop: "{{ owncloud_apps_deprecated }}"
+      when: ansible_local.owncloud.installed | bool or ansible_local.owncloud.maintenance | bool
+
+    - name: Enable maintainance mode
+      command: "{{ owncloud_occ_executable | quote }} maintenance:singleuser --on"
+      when:
+        - ansible_local.owncloud.installed | bool
+        - __occ_bin_link.stat.exists
+        - __occ_bin_src.stat.exists
+      become: True
+      become_user: "{{ owncloud_app_user }}"
+  when: owncloud_current_version is version_compare(owncloud_version, operator="<", strict=True)
 
 - block:
     - name: Copy install source to remote host

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -1,12 +1,11 @@
 ---
-- block:
-    - name: Create temp directory
-      file:
-        path: /tmp/owncloud_src
-        state: directory
-        owner: "{{ owncloud_app_user }}"
-        group: "{{ owncloud_app_group }}"
-        mode: 0750
+- name: Create temp directory
+  file:
+    path: /tmp/owncloud_src
+    state: directory
+    owner: "{{ owncloud_app_user }}"
+    group: "{{ owncloud_app_group }}"
+    mode: 0750
   when: owncloud_current_version is version_compare(owncloud_version, operator="<", strict=True)
 
 - block:


### PR DESCRIPTION
This PR contains a possible solution for https://github.com/owncloud-ansible/owncloud/issues/66. I changed the execution order so that the tmp directory is created first, then the download is initiated and afterwards the maintenance mode is activated. This way the maintenance mode isn't activated when the download fails.

The reason to mode the tmp directory creation into a separate block is that the tmp directory is also required, when the install shouldn't happen through a download (condition `- not owncloud_install_from_filesystem | bool`).