### PR TITLE
docs: add documentation for owncloud_enterprise_license_key

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,11 @@ owncloud_install_from_filesystem: False
 
 owncloud_release_channel: production
 
+# @var owncloud_enterprise_license_key:customer_date_hash: >
+# Set your enterprise license key here to use enterprise apps
+# @end
+# owncloud_enterprise_license_key: #
+
 # @var owncloud_apt_cache_update:description: >
 # Automatically update apt cache on package installations.
 # This setting will only applied on apt-based operating systems e.g. Ubuntu.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,10 +18,10 @@ owncloud_install_from_filesystem: False
 
 owncloud_release_channel: production
 
-# @var owncloud_enterprise_license_key:customer_date_hash: >
-# Set your enterprise license key here to use enterprise apps
+# @var owncloud_enterprise_license_key:description: >
+# Set your enterprise license key here to use enterprise apps.
 # @end
-# owncloud_enterprise_license_key: #
+# @var owncloud_enterprise_license_key:value: $ "_unset_"
 
 # @var owncloud_apt_cache_update:description: >
 # Automatically update apt cache on package installations.


### PR DESCRIPTION
added owncloud_enterprise_license_key variable as annotated comment to have it listed here: https://owncloud-ansible.github.io/role/owncloud/